### PR TITLE
Return the built filesystem from `generate_boot_image`

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -1880,7 +1880,7 @@ where
                         }
                     }
                 } else if bootable {
-                    let image_verity = composefs_oci::generate_boot_image(
+                    let (image_verity, _) = composefs_oci::generate_boot_image(
                         &repo,
                         &result.manifest_digest,
                         &composefs_oci::OciTransformOptions::default(),

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -2576,7 +2576,7 @@ pub mod oci {
             } else {
                 let mode = xattrs.unwrap_or_default();
                 let transform_opts = composefs_oci::OciTransformOptions { xattrs: mode };
-                let id = composefs_oci::generate_boot_image(
+                let (id, _) = composefs_oci::generate_boot_image(
                     &repo,
                     &result.manifest_digest,
                     &transform_opts,

--- a/crates/composefs-oci/src/boot.rs
+++ b/crates/composefs-oci/src/boot.rs
@@ -32,16 +32,16 @@ pub fn generate_boot_image<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     manifest_digest: &OciDigest,
     options: &OciTransformOptions,
-) -> Result<ObjectID> {
+) -> Result<(ObjectID, Option<composefs::tree::FileSystem<ObjectID>>)> {
     if let Some(existing) = boot_image_for_mode(repo, manifest_digest, options.xattrs)? {
-        return Ok(existing);
+        return Ok((existing, None));
     }
 
-    let erofs_id =
+    let (erofs_id, fs) =
         crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, None, options)?
             .expect("container image should produce boot EROFS");
 
-    Ok(erofs_id)
+    Ok((erofs_id, Some(fs)))
 }
 
 /// Result of [`find_matching_boot_image`].
@@ -356,7 +356,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let image_verity =
+        let (image_verity, _) =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -391,10 +391,12 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let v1 = generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
-            .unwrap();
-        let v2 = generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
-            .unwrap();
+        let (v1, _) =
+            generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
+                .unwrap();
+        let (v2, _) =
+            generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
+                .unwrap();
         assert_eq!(v1, v2);
     }
 
@@ -414,7 +416,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let allowlist_id = generate_boot_image(
+        let (allowlist_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -423,7 +425,7 @@ mod test {
         )
         .unwrap();
 
-        let keep_user_id = generate_boot_image(
+        let (keep_user_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -452,11 +454,11 @@ mod test {
         );
 
         // Re-generating either mode is a cache hit, returning the same image.
-        let allowlist_cached =
+        let (allowlist_cached, _) =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
         assert_eq!(allowlist_cached, allowlist_id);
-        let keep_user_cached = generate_boot_image(
+        let (keep_user_cached, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -558,7 +560,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let allowlist_id = generate_boot_image(
+        let (allowlist_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -566,7 +568,7 @@ mod test {
             },
         )
         .unwrap();
-        let keep_user_id = generate_boot_image(
+        let (keep_user_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -607,7 +609,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let image_verity =
+        let (image_verity, _) =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -672,7 +674,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let allowlist_id = generate_boot_image(
+        let (allowlist_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -707,7 +709,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let keep_user_id = generate_boot_image(
+        let (keep_user_id, _) = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -783,7 +785,7 @@ mod test {
 
         // This repo is permanently locked to V2 -- simulating an old
         // repository whose `FormatConfig` predates a newer default.
-        let v2_id =
+        let (v2_id, _) =
             generate_boot_image(&repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -831,7 +833,7 @@ mod test {
 
             let img = test_util::create_bootable_image(repo, Some(tag), 1).await;
 
-            let boot_verity =
+            let (boot_verity, _) =
                 generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                     .unwrap();
 

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -923,7 +923,7 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
     manifest_verity: Option<&ObjectID>,
     tag: Option<&str>,
     options: &composefs::generic_tree::OciTransformOptions,
-) -> Result<Option<ObjectID>> {
+) -> Result<Option<(ObjectID, composefs::tree::FileSystem<ObjectID>)>> {
     use composefs_boot::BootOps;
 
     let img = oci_image::OciImage::open(repo, manifest_digest, manifest_verity)?;
@@ -1004,7 +1004,7 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
         tag,
     )?;
 
-    Ok(Some(boot_erofs_id))
+    Ok(Some((boot_erofs_id, fs)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In bootc we call this function to generate the boot EROFS image, then we again perform a very expensive operation of re-creating the filesystem.

`generate_boot_image` already creates a filesystem, so simply return that