### PR TITLE
Return untransformed filesystem

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -1880,7 +1880,7 @@ where
                         }
                     }
                 } else if bootable {
-                    let (image_verity, _) = composefs_oci::generate_boot_image(
+                    let image_verity = composefs_oci::generate_boot_image(
                         &repo,
                         &result.manifest_digest,
                         &composefs_oci::OciTransformOptions::default(),

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -2576,7 +2576,7 @@ pub mod oci {
             } else {
                 let mode = xattrs.unwrap_or_default();
                 let transform_opts = composefs_oci::OciTransformOptions { xattrs: mode };
-                let (id, _) = composefs_oci::generate_boot_image(
+                let id = composefs_oci::generate_boot_image(
                     &repo,
                     &result.manifest_digest,
                     &transform_opts,

--- a/crates/composefs-oci/src/boot.rs
+++ b/crates/composefs-oci/src/boot.rs
@@ -32,16 +32,35 @@ pub fn generate_boot_image<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     manifest_digest: &OciDigest,
     options: &OciTransformOptions,
+) -> Result<ObjectID> {
+    if let Some(existing) = boot_image_for_mode(repo, manifest_digest, options.xattrs)? {
+        return Ok(existing);
+    }
+
+    let (erofs_id, _) =
+        crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, None, options, false)?
+            .expect("container image should produce boot EROFS");
+
+    Ok(erofs_id)
+}
+
+/// Exactly the same as [`generate_boot_image`], but also returns the untransformed
+/// filesystem created from splitstreams
+#[cfg(feature = "boot")]
+pub fn generate_boot_image_get_fs<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    manifest_digest: &OciDigest,
+    options: &OciTransformOptions,
 ) -> Result<(ObjectID, Option<composefs::tree::FileSystem<ObjectID>>)> {
     if let Some(existing) = boot_image_for_mode(repo, manifest_digest, options.xattrs)? {
         return Ok((existing, None));
     }
 
-    let (erofs_id, fs) =
-        crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, None, options)?
+    let (erofs_id, untransformed_fs) =
+        crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, None, options, true)?
             .expect("container image should produce boot EROFS");
 
-    Ok((erofs_id, Some(fs)))
+    Ok((erofs_id, untransformed_fs))
 }
 
 /// Result of [`find_matching_boot_image`].
@@ -356,7 +375,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let (image_verity, _) =
+        let image_verity =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -391,12 +410,10 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let (v1, _) =
-            generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
-                .unwrap();
-        let (v2, _) =
-            generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
-                .unwrap();
+        let v1 = generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
+            .unwrap();
+        let v2 = generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
+            .unwrap();
         assert_eq!(v1, v2);
     }
 
@@ -416,7 +433,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let (allowlist_id, _) = generate_boot_image(
+        let allowlist_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -425,7 +442,7 @@ mod test {
         )
         .unwrap();
 
-        let (keep_user_id, _) = generate_boot_image(
+        let keep_user_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -454,11 +471,11 @@ mod test {
         );
 
         // Re-generating either mode is a cache hit, returning the same image.
-        let (allowlist_cached, _) =
+        let allowlist_cached =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
         assert_eq!(allowlist_cached, allowlist_id);
-        let (keep_user_cached, _) = generate_boot_image(
+        let keep_user_cached = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -560,7 +577,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let (allowlist_id, _) = generate_boot_image(
+        let allowlist_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -568,7 +585,7 @@ mod test {
             },
         )
         .unwrap();
-        let (keep_user_id, _) = generate_boot_image(
+        let keep_user_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -609,7 +626,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let (image_verity, _) =
+        let image_verity =
             generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -674,7 +691,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let (allowlist_id, _) = generate_boot_image(
+        let allowlist_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -709,7 +726,7 @@ mod test {
             .build_oci(repo, Some("myapp:v1"))
             .await;
 
-        let (keep_user_id, _) = generate_boot_image(
+        let keep_user_id = generate_boot_image(
             repo,
             &img.manifest_digest,
             &OciTransformOptions {
@@ -785,7 +802,7 @@ mod test {
 
         // This repo is permanently locked to V2 -- simulating an old
         // repository whose `FormatConfig` predates a newer default.
-        let (v2_id, _) =
+        let v2_id =
             generate_boot_image(&repo, &img.manifest_digest, &OciTransformOptions::default())
                 .unwrap();
 
@@ -833,7 +850,7 @@ mod test {
 
             let img = test_util::create_bootable_image(repo, Some(tag), 1).await;
 
-            let (boot_verity, _) =
+            let boot_verity =
                 generate_boot_image(repo, &img.manifest_digest, &OciTransformOptions::default())
                     .unwrap();
 

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -138,7 +138,9 @@ pub(crate) fn take_boot_image_refs<ObjectID>(
 
 // Re-export key types for convenience
 #[cfg(feature = "boot")]
-pub use boot::{BootImageMatch, find_matching_boot_image, generate_boot_image};
+pub use boot::{
+    BootImageMatch, find_matching_boot_image, generate_boot_image, generate_boot_image_get_fs,
+};
 pub use boot::{boot_image, remove_boot_image};
 pub use composefs::generic_tree::{OciTransformOptions, XattrFiltering};
 pub use oci_image::{
@@ -923,7 +925,8 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
     manifest_verity: Option<&ObjectID>,
     tag: Option<&str>,
     options: &composefs::generic_tree::OciTransformOptions,
-) -> Result<Option<(ObjectID, composefs::tree::FileSystem<ObjectID>)>> {
+    get_untransformed_filesystem: bool,
+) -> Result<Option<(ObjectID, Option<composefs::tree::FileSystem<ObjectID>>)>> {
     use composefs_boot::BootOps;
 
     let img = oci_image::OciImage::open(repo, manifest_digest, manifest_verity)?;
@@ -938,6 +941,15 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
         Some(img.config_verity()),
         options,
     )?;
+
+    // We want the full filesystem to get boot entries
+    // [`transform_for_boot`] masks /boot which we don't want
+    let untransformed_fs = if get_untransformed_filesystem {
+        Some(fs.clone())
+    } else {
+        None
+    };
+
     fs.transform_for_boot(repo)?;
 
     // Commit as EROFS image(s) for all formats in the repository's default set.
@@ -1004,7 +1016,7 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
         tag,
     )?;
 
-    Ok(Some((boot_erofs_id, fs)))
+    Ok(Some((boot_erofs_id, untransformed_fs)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In https://github.com/composefs/composefs-rs/pull/376, I had forgotten that we transform the filesystem (which masks /boot) before creating the EROFS. Making off /boot is the opposite of what we need in bootc since bootc searches for boot entries in /boot