### PR TITLE
oci: Decode multi-frame compressed layers

### DIFF
--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -20,7 +20,7 @@ varlink = ['dep:zlink', 'dep:zlink-core', 'composefs/varlink']
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
-async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
+async-compression = { version = "0.4.43", default-features = false, features = ["tokio", "zstd", "gzip"] }
 base64 = { version = "0.23", default-features = false, features = ["std"], optional = true }
 composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.0", features = ["tokio"] }
 bytes = { version = "1", default-features = false }

--- a/crates/composefs-oci/src/layer.rs
+++ b/crates/composefs-oci/src/layer.rs
@@ -48,12 +48,25 @@ where
         MediaType::ImageLayer | MediaType::ImageLayerNonDistributable => {
             Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, buf))
         }
-        MediaType::ImageLayerGzip | MediaType::ImageLayerNonDistributableGzip => Box::new(
-            BufReader::with_capacity(IO_BUF_CAPACITY, GzipDecoder::new(buf)),
-        ),
-        MediaType::ImageLayerZstd | MediaType::ImageLayerNonDistributableZstd => Box::new(
-            BufReader::with_capacity(IO_BUF_CAPACITY, ZstdDecoder::new(buf)),
-        ),
+        MediaType::ImageLayerGzip | MediaType::ImageLayerNonDistributableGzip => {
+            let mut decoder = GzipDecoder::new(buf);
+            // Gzip layers may concatenate multiple members; keep decoding past
+            // the first member boundary instead of truncating there
+            // (bootc-dev/bootc#2408).
+            decoder.multiple_members(true);
+            Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, decoder))
+        }
+        MediaType::ImageLayerZstd | MediaType::ImageLayerNonDistributableZstd => {
+            let mut decoder = ZstdDecoder::new(buf);
+            // zstd:chunked layers are multi-frame streams with interleaved
+            // skippable frames (bootc-dev/bootc#2408); keep decoding past the
+            // first frame boundary instead of truncating there. Decoding
+            // multiple members requires async-compression >= 0.4.43, which
+            // fixed a hang on a corrupt later frame
+            // (Nullus157/async-compression#470).
+            decoder.multiple_members(true);
+            Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, decoder))
+        }
         _ => bail!("Unsupported layer media type for decompression: {media_type}"),
     };
     Ok(reader)
@@ -96,4 +109,119 @@ where
     let tmpfile = writer.into_std().await;
     let (object_id, method) = repo.finalize_object_tmpfile(tmpfile, size)?;
     Ok((object_id, size, method))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write as _};
+
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use tokio::io::AsyncReadExt as _;
+
+    use super::*;
+
+    /// Zstd skippable-frame magic numbers span 0x184D2A50..=0x184D2A5F (RFC 8878 §3.1.2).
+    const ZSTD_SKIPPABLE_MAGIC: u32 = 0x184D2A50;
+
+    /// Encode `data` as a standalone zstd frame.
+    fn zstd_frame(data: &[u8]) -> Vec<u8> {
+        let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// Build a zstd skippable frame (magic + LE size + payload) wrapping `payload`.
+    fn zstd_skippable_frame(payload: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(8 + payload.len());
+        frame.extend_from_slice(&ZSTD_SKIPPABLE_MAGIC.to_le_bytes());
+        frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    /// Encode `data` as a standalone gzip member.
+    fn gzip_member(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// Run `compressed` through `decompress_async` for `media_type` and collect the output.
+    async fn decompress_to_vec(media_type: MediaType, compressed: Vec<u8>) -> Vec<u8> {
+        let mut reader = decompress_async(Cursor::new(compressed), &media_type).unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await.unwrap();
+        out
+    }
+
+    #[tokio::test]
+    async fn multi_member_streams_decode_fully() {
+        // Skippable frames at the start, between real frames, and trailing
+        // must not perturb the decoded output.
+        let mut zstd_with_skippable = zstd_skippable_frame(b"leading skippable junk");
+        zstd_with_skippable.extend(zstd_frame(b"first "));
+        zstd_with_skippable.extend(zstd_skippable_frame(b"between-frame skippable junk"));
+        zstd_with_skippable.extend(zstd_frame(b"second"));
+        zstd_with_skippable.extend(zstd_skippable_frame(b"trailing skippable junk"));
+
+        let cases: &[(&str, MediaType, Vec<u8>, &[u8])] = &[
+            (
+                "zstd multi-frame concatenation",
+                MediaType::ImageLayerZstd,
+                [
+                    zstd_frame(b"first frame content, "),
+                    zstd_frame(b"second frame content"),
+                ]
+                .concat(),
+                b"first frame content, second frame content",
+            ),
+            (
+                "zstd skippable frames at start, between, and trailing",
+                MediaType::ImageLayerZstd,
+                zstd_with_skippable,
+                b"first second",
+            ),
+            (
+                "gzip multi-member concatenation",
+                MediaType::ImageLayerGzip,
+                [
+                    gzip_member(b"first member content, "),
+                    gzip_member(b"second member content"),
+                ]
+                .concat(),
+                b"first member content, second member content",
+            ),
+        ];
+
+        for (name, media_type, compressed, expected) in cases {
+            let out = decompress_to_vec(media_type.clone(), compressed.clone()).await;
+            assert_eq!(out.as_slice(), *expected, "case: {name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_second_zstd_frame_errors_promptly() {
+        // async-compression < 0.4.43 could loop forever on a corrupt later
+        // frame with multiple_members enabled
+        // (Nullus157/async-compression#470); the Cargo.toml floor plus this
+        // test pin the fixed behavior.
+        let mut compressed = zstd_frame(b"valid first frame");
+        compressed.extend_from_slice(&[0x28, 0xb5, 0x2f, 0xfd]); // zstd magic...
+        compressed.extend_from_slice(&[0xff; 32]); // ...then garbage
+
+        let mut reader =
+            decompress_async(Cursor::new(compressed), &MediaType::ImageLayerZstd).unwrap();
+        let mut out = Vec::new();
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            reader.read_to_end(&mut out),
+        )
+        .await
+        .expect("decoding a corrupt frame must fail promptly, not hang");
+        assert!(
+            read.is_err(),
+            "corrupt second frame must error, got {read:?}"
+        );
+    }
 }


### PR DESCRIPTION
zstd:chunked OCI layers are multi-frame zstd streams: one frame per chunk, plus skippable frames carrying the TOC and footer. `decompress_async()` builds its decoders with the async-compression defaults, which stop at the first frame boundary, so pulling a chunked layer truncates the decompressed tar and fails with "unexpected EOF reading tar entry" (bootc-dev/bootc#2408). Multi-member gzip streams hit the same latent truncation.

This enables `multiple_members(true)` on both decoders, so concatenated frames and members decode to the full stream, and skippable frames are skipped (libzstd handles them natively at any position). The async-compression floor moves to 0.4.43, which fixed an infinite loop on a corrupt later frame with `multiple_members` enabled (Nullus157/async-compression#470).

This is full-pull correctness only: a chunked image now pulls and mounts, but nothing exploits the TOC for partial pulls, which remains #137 and #356 territory. It is the interim described in bootc-dev/bootc#509, where the host "at least doesn't barf on them (but it won't have optimized fetches)". Without it, a composefs host whose publisher switches to zstd:chunked is stranded: the pull that would deliver any fix is the pull that fails, and recovery is publisher-side re-push or reinstall.

It also matches what already works on the OSTree backend. ostree-ext's `Decompressor` routes zstd through libzstd streaming, which decodes multiple frames and skips skippable framing natively (its own comments call out zstd:chunked's trailing metadata frames, bootc-dev/bootc#1204), and reusing that logic in composefs-rs was suggested in bootc-dev/bootc#1703. The tar import here already drains the decompressed stream to EOF after the archive terminator for diff_id fidelity, so the trailing-frame pipe hazard #1204 describes is covered on the proxy path as well.

The new tests synthesize multi-frame zstd (skippable frames leading, interleaved, and trailing), multi-member gzip, and a corrupt second frame under a timeout; the multi-member cases each fail with the fix reverted. Also verified end-to-end: a real zstd:chunked image produced by `skopeo copy --dest-compress-format zstd:chunked` fails to pull at the parent commit with exactly the production error, and pulls clean with this change.

Generated-by: AI
I diagnosed the failure on my own sealed composefs host and root-caused it to this decoder. I reviewed every line; the tests are mutation-checked.
