### PR TITLE
oci: Attribute pull errors to the failing blob

### DIFF
--- a/crates/composefs-oci/src/oci_layout.rs
+++ b/crates/composefs-oci/src/oci_layout.rs
@@ -245,7 +245,9 @@ async fn import_opened_layout<ObjectID: FsVerityHashValue, T: OciRead + Send + S
     let (config_digest, config_verity, layer_refs, stats) =
         import_config_and_layers(repo, &oci, layers, config_descriptor, &reporter)
             .await
-            .with_context(|| format!("Failed to import config {}", config_descriptor.digest()))?;
+            .with_context(|| {
+                format!("Failed to import image content for manifest {manifest_digest}")
+            })?;
 
     reporter.report(ProgressEvent::Message("Storing manifest".to_string()));
 
@@ -309,7 +311,8 @@ async fn import_config_and_layers<ObjectID: FsVerityHashValue, T: OciRead + Send
             &content_id,
             Some(&config_id),
             Some(OCI_CONFIG_CONTENT_TYPE),
-        )?;
+        )
+        .with_context(|| format!("Failed to read cached config {config_digest}"))?;
         let named_refs_map: HashMap<&str, ObjectID> = named_refs
             .iter()
             .map(|(k, v)| (k.as_ref(), v.clone()))
@@ -319,7 +322,8 @@ async fn import_config_and_layers<ObjectID: FsVerityHashValue, T: OciRead + Send
             config_descriptor.media_type(),
             data.as_slice(),
             manifest_layers,
-        )?;
+        )
+        .with_context(|| format!("Failed to parse config {config_digest}"))?;
 
         let layer_refs: Vec<(OciDigest, ObjectID)> = diff_ids
             .into_iter()
@@ -353,13 +357,15 @@ async fn import_config_and_layers<ObjectID: FsVerityHashValue, T: OciRead + Send
     debug!("Reading config {config_digest}");
     let mut raw_config = Vec::with_capacity(config_descriptor.size() as usize);
     oci.read_blob(config_descriptor)
-        .context("Reading config blob")?
-        .read_to_end(&mut raw_config)?;
+        .with_context(|| format!("Failed to read config {config_digest}"))?
+        .read_to_end(&mut raw_config)
+        .with_context(|| format!("Failed to read config {config_digest}"))?;
     let diff_ids = crate::extract_diff_ids(
         config_descriptor.media_type(),
         raw_config.as_slice(),
         manifest_layers,
-    )?;
+    )
+    .with_context(|| format!("Failed to parse config {config_digest}"))?;
 
     // Sort layers by size for parallel fetching (largest first)
     let mut layers: Vec<_> = manifest_layers.iter().zip(&diff_ids).collect();
@@ -381,6 +387,7 @@ async fn import_config_and_layers<ObjectID: FsVerityHashValue, T: OciRead + Send
 
         let media_type = descriptor.media_type().clone();
         let layer_size = descriptor.size();
+        let layer_digest = descriptor.digest().clone();
 
         layer_tasks.spawn(async move {
             let _permit = permit;
@@ -392,7 +399,8 @@ async fn import_config_and_layers<ObjectID: FsVerityHashValue, T: OciRead + Send
                 layer_size,
                 &reporter,
             )
-            .await?;
+            .await
+            .with_context(|| format!("Failed to import layer {layer_digest}"))?;
             anyhow::Ok((idx, diff_id, verity, layer_stats))
         });
     }

--- a/crates/composefs-oci/src/skopeo.rs
+++ b/crates/composefs-oci/src/skopeo.rs
@@ -308,14 +308,16 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
                 &content_id,
                 Some(&config_id),
                 Some(OCI_CONFIG_CONTENT_TYPE),
-            )?;
+            )
+            .with_context(|| format!("Failed to read cached config {config_digest}"))?;
             let named_refs_map: std::collections::HashMap<&str, ObjectID> = named_refs
                 .iter()
                 .map(|(k, v)| (k.as_ref(), v.clone()))
                 .collect();
 
             let diff_ids =
-                crate::extract_diff_ids(descriptor.media_type(), data.as_slice(), manifest_layers)?;
+                crate::extract_diff_ids(descriptor.media_type(), data.as_slice(), manifest_layers)
+                    .with_context(|| format!("Failed to parse config {config_digest}"))?;
 
             let layer_refs: Vec<(OciDigest, ObjectID)> = diff_ids
                 .into_iter()
@@ -346,15 +348,19 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
                 "Fetching config {config_digest}"
             )));
 
-            let (mut config, driver) = self.proxy.get_descriptor(&self.img, descriptor).await?;
-            let config = async move {
-                let mut s = Vec::new();
-                config.read_to_end(&mut s).await?;
-                anyhow::Ok(s)
-            };
-            let (config, driver) = tokio::join!(config, driver);
-            let _: () = driver?;
-            let raw_config = config?;
+            let raw_config = async {
+                let (mut config, driver) = self.proxy.get_descriptor(&self.img, descriptor).await?;
+                let config = async move {
+                    let mut s = Vec::new();
+                    config.read_to_end(&mut s).await?;
+                    anyhow::Ok(s)
+                };
+                let (config, driver) = tokio::join!(config, driver);
+                let _: () = driver?;
+                config
+            }
+            .await
+            .with_context(|| format!("Failed to fetch config {config_digest}"))?;
 
             // Per the OCI artifacts guidance [1], artifact configs use the
             // empty descriptor (`application/vnd.oci.empty.v1+json`) or a
@@ -365,7 +371,8 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
                 descriptor.media_type(),
                 raw_config.as_slice(),
                 manifest_layers,
-            )?;
+            )
+            .with_context(|| format!("Failed to parse config {config_digest}"))?;
 
             // Sort layers by size for parallel fetching
             let mut layers: Vec<_> = zip(manifest_layers, &diff_ids).collect();
@@ -399,7 +406,10 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
                     let _permit = permit;
                     let (verity, layer_stats) = self_
                         .ensure_layer(&diff_id, &descriptor, uncompressed_layer_info, layer_idx)
-                        .await?;
+                        .await
+                        .with_context(|| {
+                            format!("Failed to import layer {}", descriptor.digest())
+                        })?;
                     anyhow::Ok((idx, diff_id, verity, layer_stats))
                 });
             }
@@ -468,7 +478,9 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
         let (config_digest, config_verity, layer_refs, stats) = self
             .ensure_config_with_layers(layers, config_descriptor)
             .await
-            .with_context(|| format!("Failed to pull config {config_descriptor:?}"))?;
+            .with_context(|| {
+                format!("Failed to pull image content for manifest {manifest_digest}")
+            })?;
 
         let manifest_content_id = manifest_identifier(&manifest_digest);
         let manifest_verity = if let Some(verity) = self.repo.has_stream(&manifest_content_id)? {


### PR DESCRIPTION
A failure anywhere in `ensure_config_with_layers()` (the config fetch or any concurrent layer import) was reported as "Failed to pull config {descriptor}", blaming a config blob that is often intact. The `oci:` layout path has the same shape via `import_config_and_layers()`, reported as "Failed to import config". Debugging bootc-dev/bootc#2408 the config-blaming message cost an hour of registry forensics on a config blob that was byte-perfect; #99 is the same confusion from a different trigger.

Both paths now wrap each layer import with the failing layer's own digest, keep config context on the config fetch alone (which also gives `get_descriptor()` errors context they previously lacked), and reword the outer wraps to describe the manifest-level operation they actually cover. Demonstrated against a real zstd:chunked image, whose layers currently fail to decode. Before: "Failed to import config sha256:637d...: unexpected EOF reading tar entry". After: "Failed to import image content for manifest sha256:a516...", then "Failed to import layer sha256:791d...", then "unexpected EOF reading tar entry".

This is a context-only change with no behavior difference on success paths. There is no existing test seam for either pull path, so verification is clippy plus the full workspace suite plus the live before/after above.

Generated-by: AI
I hit and root-caused the misattribution on my own host and reviewed the change carefully.
