### PR TITLE
tests: Add zstd:chunked pull integration test

### DIFF
--- a/crates/composefs-integration-tests/src/tests/cli.rs
+++ b/crates/composefs-integration-tests/src/tests/cli.rs
@@ -13,7 +13,7 @@ use crate::{cfsctl, create_test_rootfs, integration_test};
 
 // Pinned composefs image ID for the deterministic OCI layout built by
 // create_oci_layout() (single layer with usr/ dir + hello.txt, mtime=1234567890).
-const OCI_LAYOUT_COMPOSEFS_ID: &str = "f7684c21050615c02cec250e0c7d4118fb0ff6340af5039e06f2f372a7614fff25dfd38cf7f28ad67\
+pub(crate) const OCI_LAYOUT_COMPOSEFS_ID: &str = "f7684c21050615c02cec250e0c7d4118fb0ff6340af5039e06f2f372a7614fff25dfd38cf7f28ad67\
      d8b86e86371b7deafa9ae4bf543630322aee6196417de92";
 // Pinned V1 composefs image ID for the same OCI layout (V1 writer: compact inodes, BFS).
 const OCI_LAYOUT_COMPOSEFS_V1_ID: &str = "d06f1f6a73f62ed48e05ce9442ff045cdf2a9f5ba1ec623795de3d6177a253d9\

--- a/crates/composefs-integration-tests/src/tests/mod.rs
+++ b/crates/composefs-integration-tests/src/tests/mod.rs
@@ -9,3 +9,4 @@ pub mod old_format;
 pub mod ostree;
 pub mod privileged;
 pub mod varlink;
+pub mod zstd_chunked;

--- a/crates/composefs-integration-tests/src/tests/zstd_chunked.rs
+++ b/crates/composefs-integration-tests/src/tests/zstd_chunked.rs
@@ -1,0 +1,122 @@
+//! Integration test for pulling `zstd:chunked`-compressed OCI layers.
+//!
+//! `zstd:chunked` layers are multi-frame zstd streams (one frame per
+//! chunk, plus skippable framing metadata carrying the chunk table of
+//! contents), so pulling one exercises the decoder's multi-frame path.
+
+use anyhow::Result;
+use xshell::{Shell, cmd};
+
+use crate::tests::cli::{OCI_LAYOUT_COMPOSEFS_ID, create_oci_layout, init_insecure_repo};
+use crate::{cfsctl, integration_test};
+
+/// Returns true if skopeo is available on the system.
+fn have_skopeo() -> bool {
+    std::process::Command::new("skopeo")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Regression test for multi-frame zstd decoding: before the decode fix,
+/// every `zstd:chunked` pull silently imported a truncated tar because the
+/// decoder stopped at the first frame boundary.
+///
+/// Recompresses the deterministic OCI layout from [`create_oci_layout`] to
+/// `zstd:chunked` with skopeo and pulls it with `cfsctl oci pull oci:`. The
+/// `oci:` import path shares `decompress_async()` with the skopeo-proxy
+/// registry path, so this exercises the same decoder a `docker://` pull
+/// would without needing a registry.
+fn test_zstd_chunked_pull() -> Result<()> {
+    if !have_skopeo() {
+        eprintln!("skopeo not found, skipping zstd:chunked pull test");
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    // Build the plain-gzip fixture locally (no network).
+    let src_layout = create_oci_layout(fixture_dir.path())?;
+    let dst_layout = fixture_dir.path().join("zstd-chunked-image");
+
+    // Recompress into zstd:chunked. --dest-force-compress-format makes this
+    // deterministic regardless of the source's compression (without it,
+    // skopeo may leave a layer alone if it judges the codec family already
+    // matches the target).
+    let copy_result = cmd!(
+        sh,
+        "skopeo copy --dest-compress-format zstd:chunked --dest-force-compress-format oci:{src_layout} oci:{dst_layout}:chunked"
+    )
+    .ignore_status()
+    .output()?;
+    if !copy_result.status.success() {
+        eprintln!(
+            "skopeo copy --dest-compress-format zstd:chunked failed (installed skopeo may \
+             predate zstd:chunked support); skipping zstd:chunked pull test. stderr:\n{}",
+            String::from_utf8_lossy(&copy_result.stderr)
+        );
+        return Ok(());
+    }
+
+    // Assert the produced manifest actually carries the zstd:chunked TOC
+    // annotation, so this fixture can never silently degrade to plain zstd
+    // (e.g. a future skopeo treating the format as unsupported and falling
+    // back quietly, or the flags above ceasing to be honored).
+    let raw_manifest = cmd!(sh, "skopeo inspect --raw oci:{dst_layout}:chunked").read()?;
+    let manifest: serde_json::Value = serde_json::from_str(&raw_manifest)?;
+    let layers = manifest["layers"]
+        .as_array()
+        .expect("manifest should have a layers array");
+    assert_eq!(layers.len(), 1, "expected the single-layer test fixture");
+    let toc_checksum =
+        layers[0]["annotations"]["io.github.containers.zstd-chunked.manifest-checksum"].as_str();
+    assert!(
+        toc_checksum.is_some_and(|d| d.starts_with("sha256:")),
+        "layer should carry the zstd:chunked TOC manifest-checksum annotation \
+         (fixture degraded to plain zstd?), got manifest: {raw_manifest}"
+    );
+
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+    let pull_output = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{dst_layout}:chunked chunked-image"
+    )
+    .read()?;
+    assert!(
+        pull_output.contains("manifest sha256:"),
+        "expected manifest digest in pull output, got: {pull_output}"
+    );
+    assert!(
+        pull_output.contains("tagged") && pull_output.contains("chunked-image"),
+        "expected tagged confirmation, got: {pull_output}"
+    );
+
+    // The recompressed image carries the same diff_ids as the gzip original,
+    // so the imported composefs image ID must be byte-identical to the
+    // pinned gzip result.
+    let config_digest = pull_output
+        .lines()
+        .find_map(|l| l.strip_prefix("config").map(|s| s.trim().to_string()))
+        .expect("config digest in pull output");
+    let at_config_digest = format!("@{config_digest}");
+    let image_id = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci compute-id {at_config_digest}"
+    )
+    .read()?;
+    assert_eq!(
+        image_id.trim(),
+        OCI_LAYOUT_COMPOSEFS_ID,
+        "zstd:chunked pull produced a different composefs image ID than the identical content \
+         pulled as plain gzip — the multi-frame decode likely truncated the tar stream"
+    );
+
+    Ok(())
+}
+integration_test!(test_zstd_chunked_pull);

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -20,7 +20,7 @@ varlink = ['dep:zlink', 'dep:zlink-core', 'composefs/varlink']
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
-async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
+async-compression = { version = "0.4.43", default-features = false, features = ["tokio", "zstd", "gzip"] }
 base64 = { version = "0.23", default-features = false, features = ["std"], optional = true }
 composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.0", features = ["tokio"] }
 bytes = { version = "1", default-features = false }

--- a/crates/composefs-oci/src/layer.rs
+++ b/crates/composefs-oci/src/layer.rs
@@ -48,12 +48,25 @@ where
         MediaType::ImageLayer | MediaType::ImageLayerNonDistributable => {
             Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, buf))
         }
-        MediaType::ImageLayerGzip | MediaType::ImageLayerNonDistributableGzip => Box::new(
-            BufReader::with_capacity(IO_BUF_CAPACITY, GzipDecoder::new(buf)),
-        ),
-        MediaType::ImageLayerZstd | MediaType::ImageLayerNonDistributableZstd => Box::new(
-            BufReader::with_capacity(IO_BUF_CAPACITY, ZstdDecoder::new(buf)),
-        ),
+        MediaType::ImageLayerGzip | MediaType::ImageLayerNonDistributableGzip => {
+            let mut decoder = GzipDecoder::new(buf);
+            // Gzip layers may concatenate multiple members; keep decoding past
+            // the first member boundary instead of truncating there
+            // (bootc-dev/bootc#2408).
+            decoder.multiple_members(true);
+            Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, decoder))
+        }
+        MediaType::ImageLayerZstd | MediaType::ImageLayerNonDistributableZstd => {
+            let mut decoder = ZstdDecoder::new(buf);
+            // zstd:chunked layers are multi-frame streams with interleaved
+            // skippable frames (bootc-dev/bootc#2408); keep decoding past the
+            // first frame boundary instead of truncating there. Decoding
+            // multiple members requires async-compression >= 0.4.43, which
+            // fixed a hang on a corrupt later frame
+            // (Nullus157/async-compression#470).
+            decoder.multiple_members(true);
+            Box::new(BufReader::with_capacity(IO_BUF_CAPACITY, decoder))
+        }
         _ => bail!("Unsupported layer media type for decompression: {media_type}"),
     };
     Ok(reader)
@@ -96,4 +109,119 @@ where
     let tmpfile = writer.into_std().await;
     let (object_id, method) = repo.finalize_object_tmpfile(tmpfile, size)?;
     Ok((object_id, size, method))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write as _};
+
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use tokio::io::AsyncReadExt as _;
+
+    use super::*;
+
+    /// Zstd skippable-frame magic numbers span 0x184D2A50..=0x184D2A5F (RFC 8878 §3.1.2).
+    const ZSTD_SKIPPABLE_MAGIC: u32 = 0x184D2A50;
+
+    /// Encode `data` as a standalone zstd frame.
+    fn zstd_frame(data: &[u8]) -> Vec<u8> {
+        let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 0).unwrap();
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// Build a zstd skippable frame (magic + LE size + payload) wrapping `payload`.
+    fn zstd_skippable_frame(payload: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(8 + payload.len());
+        frame.extend_from_slice(&ZSTD_SKIPPABLE_MAGIC.to_le_bytes());
+        frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    /// Encode `data` as a standalone gzip member.
+    fn gzip_member(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// Run `compressed` through `decompress_async` for `media_type` and collect the output.
+    async fn decompress_to_vec(media_type: MediaType, compressed: Vec<u8>) -> Vec<u8> {
+        let mut reader = decompress_async(Cursor::new(compressed), &media_type).unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).await.unwrap();
+        out
+    }
+
+    #[tokio::test]
+    async fn multi_member_streams_decode_fully() {
+        // Skippable frames at the start, between real frames, and trailing
+        // must not perturb the decoded output.
+        let mut zstd_with_skippable = zstd_skippable_frame(b"leading skippable junk");
+        zstd_with_skippable.extend(zstd_frame(b"first "));
+        zstd_with_skippable.extend(zstd_skippable_frame(b"between-frame skippable junk"));
+        zstd_with_skippable.extend(zstd_frame(b"second"));
+        zstd_with_skippable.extend(zstd_skippable_frame(b"trailing skippable junk"));
+
+        let cases: &[(&str, MediaType, Vec<u8>, &[u8])] = &[
+            (
+                "zstd multi-frame concatenation",
+                MediaType::ImageLayerZstd,
+                [
+                    zstd_frame(b"first frame content, "),
+                    zstd_frame(b"second frame content"),
+                ]
+                .concat(),
+                b"first frame content, second frame content",
+            ),
+            (
+                "zstd skippable frames at start, between, and trailing",
+                MediaType::ImageLayerZstd,
+                zstd_with_skippable,
+                b"first second",
+            ),
+            (
+                "gzip multi-member concatenation",
+                MediaType::ImageLayerGzip,
+                [
+                    gzip_member(b"first member content, "),
+                    gzip_member(b"second member content"),
+                ]
+                .concat(),
+                b"first member content, second member content",
+            ),
+        ];
+
+        for (name, media_type, compressed, expected) in cases {
+            let out = decompress_to_vec(media_type.clone(), compressed.clone()).await;
+            assert_eq!(out.as_slice(), *expected, "case: {name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupt_second_zstd_frame_errors_promptly() {
+        // async-compression < 0.4.43 could loop forever on a corrupt later
+        // frame with multiple_members enabled
+        // (Nullus157/async-compression#470); the Cargo.toml floor plus this
+        // test pin the fixed behavior.
+        let mut compressed = zstd_frame(b"valid first frame");
+        compressed.extend_from_slice(&[0x28, 0xb5, 0x2f, 0xfd]); // zstd magic...
+        compressed.extend_from_slice(&[0xff; 32]); // ...then garbage
+
+        let mut reader =
+            decompress_async(Cursor::new(compressed), &MediaType::ImageLayerZstd).unwrap();
+        let mut out = Vec::new();
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            reader.read_to_end(&mut out),
+        )
+        .await
+        .expect("decoding a corrupt frame must fail promptly, not hang");
+        assert!(
+            read.is_err(),
+            "corrupt second frame must error, got {read:?}"
+        );
+    }
 }


### PR DESCRIPTION
Adds the zstd:chunked integration coverage flagged in review on #381: build the same deterministic OCI layout `tests::cli` pins, recompress it to zstd:chunked with skopeo, assert the manifest really carries the zstd:chunked TOC annotation, pull it through `cfsctl oci pull oci:`, and assert the imported composefs image ID is byte-identical to the same content pulled as plain gzip. This is regression coverage for the decode failure tracked in #383. Skips when skopeo is absent or its copy rejects zstd:chunked, mirroring `tests::old_format`.

Verified in a VM with skopeo available: the test executes the real path (not the skip), fails with the multi-frame decode fix reverted, and passes on top of #381 with no change to the rest of the suite.

Based on #381, so the diff shows its commit until it merges; only the last commit is new here. I'll rebase onto main once #381 lands.

Generated-by: AI. I am familiar with the decode change under test and reviewed this carefully.
