### PR TITLE
Erofs counterparts

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -554,6 +554,11 @@ enum OciCommand {
         #[clap(long, value_hint = clap::ValueHint::AnyPath)]
         address: Option<PathBuf>,
     },
+    /// Find boot/non-boot counterparts of an EROFS image
+    ErofsCounterparts {
+        /// Fsverity digest of an EROFS image
+        verity: String,
+    },
 }
 
 #[cfg(feature = "ostree")]
@@ -2181,6 +2186,19 @@ where
             }
             OciCommand::Varlink { .. } => {
                 unreachable!("oci varlink is handled before opening a repository");
+            }
+            OciCommand::ErofsCounterparts { ref verity } => {
+                use composefs_oci::RepositoryOciExt;
+                let id = ObjectID::from_hex(verity)?;
+                let counterparts = repo.erofs_counterparts(&id)?;
+                if counterparts.is_empty() {
+                    println!("No counterparts found for {verity}");
+                    return Ok(());
+                }
+
+                for c in &counterparts {
+                    println!("{}", c.to_hex());
+                }
             }
         },
         #[cfg(feature = "ostree")]

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -554,9 +554,9 @@ enum OciCommand {
         #[clap(long, value_hint = clap::ValueHint::AnyPath)]
         address: Option<PathBuf>,
     },
-    /// Find boot/non-boot counterparts of an EROFS image
-    ErofsCounterparts {
-        /// Fsverity digest of an EROFS image
+    /// List all EROFS images linked to the same OCI image
+    LinkedErofsImages {
+        /// Hex fs-verity digest of an EROFS image
         verity: String,
     },
 }
@@ -2187,18 +2187,12 @@ where
             OciCommand::Varlink { .. } => {
                 unreachable!("oci varlink is handled before opening a repository");
             }
-            OciCommand::ErofsCounterparts { ref verity } => {
+            OciCommand::LinkedErofsImages { ref verity } => {
                 use composefs_oci::RepositoryOciExt;
                 let id = ObjectID::from_hex(verity)?;
-                let counterparts = repo.erofs_counterparts(&id)?;
-                if counterparts.is_empty() {
-                    println!("No counterparts found for {verity}");
-                    return Ok(());
-                }
-
-                for c in &counterparts {
-                    println!("{}", c.to_hex());
-                }
+                let images = repo.linked_erofs_images(&id)?;
+                serde_json::to_writer_pretty(std::io::stdout().lock(), &images)?;
+                println!();
             }
         },
         #[cfg(feature = "ostree")]

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -2188,9 +2188,8 @@ where
                 unreachable!("oci varlink is handled before opening a repository");
             }
             OciCommand::LinkedErofsImages { ref verity } => {
-                use composefs_oci::RepositoryOciExt;
                 let id = ObjectID::from_hex(verity)?;
-                let images = repo.linked_erofs_images(&id)?;
+                let images = composefs_oci::linked_erofs_images(&repo, &id)?;
                 serde_json::to_writer_pretty(std::io::stdout().lock(), &images)?;
                 println!();
             }

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -143,8 +143,8 @@ pub use boot::{boot_image, remove_boot_image};
 pub use composefs::generic_tree::{OciTransformOptions, XattrFiltering};
 pub use oci_image::{
     ImageInfo, LayerInfo, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage, OciImageNotFound,
-    OciRefNotFound, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info, layer_tar,
-    list_images, list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
+    OciRefNotFound, RepositoryOciExt, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info,
+    layer_tar, list_images, list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
     remove_referrers_for_subject, resolve_ref, tag_image, untag_image,
 };
 pub use progress::{ComponentId, NullReporter, ProgressEvent, ProgressReporter, SharedReporter};

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -142,10 +142,11 @@ pub use boot::{BootImageMatch, find_matching_boot_image, generate_boot_image};
 pub use boot::{boot_image, remove_boot_image};
 pub use composefs::generic_tree::{OciTransformOptions, XattrFiltering};
 pub use oci_image::{
-    ImageInfo, LayerInfo, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage, OciImageNotFound,
-    OciRefNotFound, RepositoryOciExt, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info,
-    layer_tar, list_images, list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
-    remove_referrers_for_subject, resolve_ref, tag_image, untag_image,
+    ImageInfo, LayerInfo, LinkedErofsImage, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage,
+    OciImageNotFound, OciRefNotFound, RepositoryOciExt, SplitstreamInfo, add_referrer,
+    layer_dumpfile, layer_info, layer_tar, list_images, list_referrers, list_refs, oci_fsck,
+    oci_fsck_image, remove_referrer, remove_referrers_for_subject, resolve_ref, tag_image,
+    untag_image,
 };
 pub use progress::{ComponentId, NullReporter, ProgressEvent, ProgressReporter, SharedReporter};
 pub use skopeo::pull_image;

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -143,8 +143,8 @@ pub use boot::{boot_image, remove_boot_image};
 pub use composefs::generic_tree::{OciTransformOptions, XattrFiltering};
 pub use oci_image::{
     ImageInfo, LayerInfo, LinkedErofsImage, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage,
-    OciImageNotFound, OciRefNotFound, RepositoryOciExt, SplitstreamInfo, add_referrer,
-    layer_dumpfile, layer_info, layer_tar, list_images, list_referrers, list_refs, oci_fsck,
+    OciImageNotFound, OciRefNotFound, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info,
+    layer_tar, linked_erofs_images, list_images, list_referrers, list_refs, oci_fsck,
     oci_fsck_image, remove_referrer, remove_referrers_for_subject, resolve_ref, tag_image,
     untag_image,
 };

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -87,6 +87,57 @@ pub struct OciErofsNotFound {
     pub bootable: bool,
 }
 
+/// An EROFS image ref paired with metadata describing which variant it is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkedErofsImage<ObjectID: FsVerityHashValue> {
+    /// The fs-verity hash of the EROFS image.
+    pub id: ObjectID,
+    /// Whether this is a boot-transformed image.
+    pub bootable: bool,
+    /// The EROFS format version.
+    pub version: FormatVersion,
+    /// The xattr filtering mode used to build this image.
+    /// `None` for non-boot images (xattr filtering only applies to
+    /// boot transforms).
+    pub xattr_mode: Option<XattrFiltering>,
+}
+
+impl<ObjectID: FsVerityHashValue> Serialize for LinkedErofsImage<ObjectID> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut st = s.serialize_struct("LinkedErofsImage", 4)?;
+        st.serialize_field("id", &self.id.to_hex())?;
+        st.serialize_field("bootable", &self.bootable)?;
+        st.serialize_field("version", &self.version)?;
+        st.serialize_field(
+            "xattrMode",
+            &self.xattr_mode.as_ref().map(|m| m.to_string()),
+        )?;
+        st.end()
+    }
+}
+
+/// Parse a boot image ref key into (FormatVersion, XattrFiltering).
+///
+/// Keys look like:
+/// - `"composefs.image.boot"` -> (V2, AllowlistOnly)
+/// - `"composefs.image.boot.v1"` -> (V1, AllowlistOnly)
+/// - `"composefs.image.boot.xattrs=keep-user-xattrs"` -> (V2, KeepUserXattrs)
+/// - `"composefs.image.boot.v1.xattrs=keep-user-xattrs"` -> (V1, KeepUserXattrs)
+fn parse_boot_ref_key(key: &str) -> (FormatVersion, XattrFiltering) {
+    let is_v1 = key.starts_with(crate::BOOT_IMAGE_REF_KEY_V1);
+    let version = if is_v1 {
+        FormatVersion::V1
+    } else {
+        FormatVersion::V2
+    };
+    let mode = key
+        .split_once(".xattrs=")
+        .and_then(|(_, mode_str)| mode_str.parse().ok())
+        .unwrap_or(XattrFiltering::AllowlistOnly);
+    (version, mode)
+}
+
 /// Data and named refs from a splitstream with external object storage.
 type ExternalData<ObjectID> = (Vec<u8>, HashMap<Box<str>, ObjectID>);
 
@@ -383,59 +434,70 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         })
     }
 
-    /// Given an EROFS image ObjectID (boot or non-boot), returns all
-    /// counterparts from the opposite category at the same epoch
+    /// Returns true if `id` matches any EROFS image ref (boot or non-boot)
+    /// stored in this OCI image.
+    pub fn has_erofs_id(&self, id: &ObjectID) -> bool {
+        if self.image_ref.as_ref() == Some(id) || self.image_ref_v1.as_ref() == Some(id) {
+            return true;
+        }
+        for value in self.boot_image_refs.values() {
+            if value == id {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns all EROFS image refs associated with this OCI image.
     ///
-    /// - Non-boot ref: returns the boot ref at the same epoch
-    /// - Boot ref: returns the non-boot ref at the same epoch
-    /// - Unknown `id`: returns an empty vec.
-    pub fn erofs_counterparts(&self, id: &ObjectID) -> Vec<&ObjectID> {
+    /// This includes both boot and non-boot variants across all format
+    /// versions and xattr filtering modes.
+    pub fn all_erofs_images(&self) -> Vec<LinkedErofsImage<ObjectID>> {
+        let mut result = Vec::new();
+
+        if let Some(id) = &self.image_ref {
+            result.push(LinkedErofsImage {
+                id: id.clone(),
+                bootable: false,
+                version: FormatVersion::V2,
+                // non-boot images aren't built with any xattr filtering
+                xattr_mode: None,
+            });
+        }
+
+        if let Some(id) = &self.image_ref_v1 {
+            result.push(LinkedErofsImage {
+                id: id.clone(),
+                bootable: false,
+                version: FormatVersion::V1,
+                // non-boot images aren't built with any xattr filtering
+                xattr_mode: None,
+            });
+        }
+
         for (key, value) in &self.boot_image_refs {
-            if value != id {
-                continue;
-            }
-
-            let non_boot = if key.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
-                self.image_ref_v1.as_ref()
-            } else {
-                self.image_ref.as_ref()
-            };
-
-            return non_boot.into_iter().collect();
+            let (version, mode) = parse_boot_ref_key(key);
+            result.push(LinkedErofsImage {
+                id: value.clone(),
+                bootable: true,
+                version,
+                xattr_mode: Some(mode),
+            });
         }
 
-        // Non boot image passed in
-        if self.image_ref.as_ref() == Some(id) {
-            let mut v = vec![];
+        result
+    }
 
-            for (boot_img, id) in &self.boot_image_refs {
-                if boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
-                    continue;
-                }
-
-                if !boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY) {
-                    continue;
-                }
-
-                v.push(id);
-            }
-
-            return v;
+    /// Given an EROFS image ObjectID (boot or non-boot), returns all
+    /// EROFS image refs associated with the same OCI image
+    ///
+    /// Returns an empty vec if `id` does not match any known EROFS
+    /// image ref in this image
+    pub fn linked_erofs_images(&self, id: &ObjectID) -> Vec<LinkedErofsImage<ObjectID>> {
+        if !self.has_erofs_id(id) {
+            return Vec::new();
         }
-
-        if self.image_ref_v1.as_ref() == Some(id) {
-            let mut v = vec![];
-
-            for (boot_img, id) in &self.boot_image_refs {
-                if boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
-                    v.push(id);
-                }
-            }
-
-            return v;
-        }
-
-        Vec::new()
+        self.all_erofs_images()
     }
 
     /// Reads the already-committed EROFS image for this OCI image back into a
@@ -651,21 +713,21 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
 pub trait RepositoryOciExt<ObjectID: FsVerityHashValue> {
     /// Given an EROFS image ObjectID (boot or non-boot), scans all tagged OCI
     /// images and returns every counterpart from the opposite category.
-    fn erofs_counterparts(&self, id: &ObjectID) -> Result<Vec<ObjectID>>;
+    fn linked_erofs_images(&self, id: &ObjectID) -> Result<Vec<LinkedErofsImage<ObjectID>>>;
 }
 
 impl<ObjectID: FsVerityHashValue> RepositoryOciExt<ObjectID> for Repository<ObjectID> {
-    fn erofs_counterparts(&self, id: &ObjectID) -> Result<Vec<ObjectID>> {
+    fn linked_erofs_images(&self, id: &ObjectID) -> Result<Vec<LinkedErofsImage<ObjectID>>> {
         for (_, digest) in list_refs(self)? {
             if let Ok(img) = OciImage::open(self, &digest, None) {
-                let counterparts = img.erofs_counterparts(id);
+                let counterparts = img.linked_erofs_images(id);
                 if !counterparts.is_empty() {
-                    return Ok(counterparts.into_iter().cloned().collect());
+                    return Ok(counterparts);
                 }
             }
         }
 
-        Err(anyhow::anyhow!("No EORFS image found {}", id.to_hex()))
+        Err(anyhow::anyhow!("No EROFS image found {}", id.to_hex()))
     }
 }
 
@@ -4099,7 +4161,7 @@ mod test {
     }
 
     #[test]
-    fn test_erofs_counterparts() {
+    fn test_linked_erofs_images() {
         let test_repo = TestRepo::<Sha256HashValue>::new();
         let repo = &test_repo.repo;
 
@@ -4159,53 +4221,71 @@ mod test {
         .unwrap();
 
         let img2 = OciImage::open_ref(&repo, "cparts:v1").unwrap();
+        use composefs::erofs::format::FormatVersion;
+        use composefs::generic_tree::XattrFiltering;
 
-        // Non-boot V2 → both V2 boot images
-        let mut v2_counterparts = img2.erofs_counterparts(&fake_nonboot_v2);
-        v2_counterparts.sort_by_key(|id| id.to_hex());
-        let mut expected_v2 = vec![&fake_boot_v2, &fake_boot_v2_xattr];
-        expected_v2.sort_by_key(|id| id.to_hex());
-        assert_eq!(v2_counterparts, expected_v2);
+        // Non-boot V2 -> both V2 boot images
+        let mut expected_all = vec![
+            LinkedErofsImage {
+                id: fake_nonboot_v2.clone(),
+                bootable: false,
+                version: FormatVersion::V2,
+                xattr_mode: None,
+            },
+            LinkedErofsImage {
+                id: fake_nonboot_v1.clone(),
+                bootable: false,
+                version: FormatVersion::V1,
+                xattr_mode: None,
+            },
+            LinkedErofsImage {
+                id: fake_boot_v2.clone(),
+                bootable: true,
+                version: FormatVersion::V2,
+                xattr_mode: Some(XattrFiltering::AllowlistOnly),
+            },
+            LinkedErofsImage {
+                id: fake_boot_v2_xattr.clone(),
+                bootable: true,
+                version: FormatVersion::V2,
+                xattr_mode: Some(XattrFiltering::KeepUserXattrs),
+            },
+            LinkedErofsImage {
+                id: fake_boot_v1.clone(),
+                bootable: true,
+                version: FormatVersion::V1,
+                xattr_mode: Some(XattrFiltering::AllowlistOnly),
+            },
+        ];
+        expected_all.sort_by_key(|c| c.id.to_hex());
 
-        // Non-boot V1 → V1 boot image
-        assert_eq!(
-            img2.erofs_counterparts(&fake_nonboot_v1),
-            vec![&fake_boot_v1],
-        );
+        // Any known ID returns the full set
+        for id in [
+            &fake_nonboot_v2,
+            &fake_nonboot_v1,
+            &fake_boot_v2,
+            &fake_boot_v2_xattr,
+            &fake_boot_v1,
+        ] {
+            let mut result = img2.linked_erofs_images(id);
+            result.sort_by_key(|c| c.id.to_hex());
+            assert_eq!(result, expected_all, "mismatch for id {}", id.to_hex());
+        }
 
-        // Boot V2 → non-boot V2
-        assert_eq!(
-            img2.erofs_counterparts(&fake_boot_v2),
-            vec![&fake_nonboot_v2],
-        );
-
-        // Boot V2 (xattr variant) → non-boot V2
-        assert_eq!(
-            img2.erofs_counterparts(&fake_boot_v2_xattr),
-            vec![&fake_nonboot_v2],
-        );
-
-        // Boot V1 → non-boot V1
-        assert_eq!(
-            img2.erofs_counterparts(&fake_boot_v1),
-            vec![&fake_nonboot_v1],
-        );
-
-        // Unknown → empty
+        // Unknown -> empty
         let unknown: Sha256HashValue = composefs::fsverity::compute_verity(b"unknown");
-        assert!(img2.erofs_counterparts(&unknown).is_empty());
+        assert!(img2.linked_erofs_images(&unknown).is_empty());
 
-        // Repo-level extension trait: same results without loading OciImage
-        let mut repo_v2 = repo.erofs_counterparts(&fake_nonboot_v2).unwrap();
-        repo_v2.sort_by_key(|id| id.to_hex());
-        let mut expected_v2_owned = vec![fake_boot_v2.clone(), fake_boot_v2_xattr.clone()];
-        expected_v2_owned.sort_by_key(|id| id.to_hex());
-        assert_eq!(repo_v2, expected_v2_owned);
+        // all_erofs_images returns the same set unconditionally
+        let mut all = img2.all_erofs_images();
+        all.sort_by_key(|c| c.id.to_hex());
+        assert_eq!(all, expected_all);
 
-        assert_eq!(
-            repo.erofs_counterparts(&fake_boot_v1).unwrap(),
-            vec![fake_nonboot_v1],
-        );
-        assert!(repo.erofs_counterparts(&unknown).is_err());
+        // Repo-level extension trait
+        let mut repo_result = repo.linked_erofs_images(&fake_boot_v2).unwrap();
+        repo_result.sort_by_key(|c| c.id.to_hex());
+        assert_eq!(repo_result, expected_all);
+
+        assert!(repo.linked_erofs_images(&unknown).is_err());
     }
 }

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -4097,4 +4097,115 @@ mod test {
             "boot-transformed /boot should have been emptied: {boot_entries:?}"
         );
     }
+
+    #[test]
+    fn test_erofs_counterparts() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = &test_repo.repo;
+
+        let (manifest_digest, manifest_verity, _) =
+            create_test_image(repo, Some("cparts:v1"), "amd64");
+
+        let img = OciImage::open(&repo, &manifest_digest, Some(&manifest_verity)).unwrap();
+
+        let fake_nonboot_v2: Sha256HashValue =
+            composefs::fsverity::compute_verity(b"fake-nonboot-v2");
+        let fake_nonboot_v1: Sha256HashValue =
+            composefs::fsverity::compute_verity(b"fake-nonboot-v1");
+        let fake_boot_v2: Sha256HashValue = composefs::fsverity::compute_verity(b"fake-boot-v2");
+        let fake_boot_v2_xattr: Sha256HashValue =
+            composefs::fsverity::compute_verity(b"fake-boot-v2-keepuser");
+        let fake_boot_v1: Sha256HashValue = composefs::fsverity::compute_verity(b"fake-boot-v1");
+
+        let mut boot_images = std::collections::HashMap::new();
+        boot_images.insert(Box::from(crate::BOOT_IMAGE_REF_KEY), fake_boot_v2.clone());
+        boot_images.insert(
+            Box::from(format!(
+                "{}.xattrs=keep-user-xattrs",
+                crate::BOOT_IMAGE_REF_KEY
+            )),
+            fake_boot_v2_xattr.clone(),
+        );
+        boot_images.insert(
+            Box::from(crate::BOOT_IMAGE_REF_KEY_V1),
+            fake_boot_v1.clone(),
+        );
+
+        let config_json = img.read_config_json(&repo).unwrap();
+        let (_, new_config_verity) = crate::write_config_raw(
+            repo,
+            &config_json,
+            img.layer_refs().clone(),
+            Some(&fake_nonboot_v2),
+            Some(&fake_nonboot_v1),
+            &boot_images,
+        )
+        .unwrap();
+
+        let manifest_json = img.read_manifest_json(&repo).unwrap();
+        let layer_verities: Vec<_> = img
+            .layer_refs()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        rewrite_manifest(
+            repo,
+            &manifest_json,
+            &manifest_digest,
+            &new_config_verity,
+            &layer_verities,
+            Some("cparts:v1"),
+        )
+        .unwrap();
+
+        let img2 = OciImage::open_ref(&repo, "cparts:v1").unwrap();
+
+        // Non-boot V2 → both V2 boot images
+        let mut v2_counterparts = img2.erofs_counterparts(&fake_nonboot_v2);
+        v2_counterparts.sort_by_key(|id| id.to_hex());
+        let mut expected_v2 = vec![&fake_boot_v2, &fake_boot_v2_xattr];
+        expected_v2.sort_by_key(|id| id.to_hex());
+        assert_eq!(v2_counterparts, expected_v2);
+
+        // Non-boot V1 → V1 boot image
+        assert_eq!(
+            img2.erofs_counterparts(&fake_nonboot_v1),
+            vec![&fake_boot_v1],
+        );
+
+        // Boot V2 → non-boot V2
+        assert_eq!(
+            img2.erofs_counterparts(&fake_boot_v2),
+            vec![&fake_nonboot_v2],
+        );
+
+        // Boot V2 (xattr variant) → non-boot V2
+        assert_eq!(
+            img2.erofs_counterparts(&fake_boot_v2_xattr),
+            vec![&fake_nonboot_v2],
+        );
+
+        // Boot V1 → non-boot V1
+        assert_eq!(
+            img2.erofs_counterparts(&fake_boot_v1),
+            vec![&fake_nonboot_v1],
+        );
+
+        // Unknown → empty
+        let unknown: Sha256HashValue = composefs::fsverity::compute_verity(b"unknown");
+        assert!(img2.erofs_counterparts(&unknown).is_empty());
+
+        // Repo-level extension trait: same results without loading OciImage
+        let mut repo_v2 = repo.erofs_counterparts(&fake_nonboot_v2).unwrap();
+        repo_v2.sort_by_key(|id| id.to_hex());
+        let mut expected_v2_owned = vec![fake_boot_v2.clone(), fake_boot_v2_xattr.clone()];
+        expected_v2_owned.sort_by_key(|id| id.to_hex());
+        assert_eq!(repo_v2, expected_v2_owned);
+
+        assert_eq!(
+            repo.erofs_counterparts(&fake_boot_v1).unwrap(),
+            vec![fake_nonboot_v1],
+        );
+        assert!(repo.erofs_counterparts(&unknown).is_err());
+    }
 }

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -440,12 +440,7 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         if self.image_ref.as_ref() == Some(id) || self.image_ref_v1.as_ref() == Some(id) {
             return true;
         }
-        for value in self.boot_image_refs.values() {
-            if value == id {
-                return true;
-            }
-        }
-        false
+        self.boot_image_refs.values().any(|v| v == id)
     }
 
     /// Returns all EROFS image refs associated with this OCI image.
@@ -709,26 +704,22 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
     }
 }
 
-/// Extension trait that adds OCI EROFS counterpart lookups to [`Repository`].
-pub trait RepositoryOciExt<ObjectID: FsVerityHashValue> {
-    /// Given an EROFS image ObjectID (boot or non-boot), scans all tagged OCI
-    /// images and returns every counterpart from the opposite category.
-    fn linked_erofs_images(&self, id: &ObjectID) -> Result<Vec<LinkedErofsImage<ObjectID>>>;
-}
-
-impl<ObjectID: FsVerityHashValue> RepositoryOciExt<ObjectID> for Repository<ObjectID> {
-    fn linked_erofs_images(&self, id: &ObjectID) -> Result<Vec<LinkedErofsImage<ObjectID>>> {
-        for (_, digest) in list_refs(self)? {
-            if let Ok(img) = OciImage::open(self, &digest, None) {
-                let counterparts = img.linked_erofs_images(id);
-                if !counterparts.is_empty() {
-                    return Ok(counterparts);
-                }
+/// Given an EROFS image ObjectID (boot or non-boot), scans all tagged OCI
+/// images and returns every counterpart from the opposite category.
+pub fn linked_erofs_images<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    id: &ObjectID,
+) -> Result<Vec<LinkedErofsImage<ObjectID>>> {
+    for (_, digest) in list_refs(repo)? {
+        if let Ok(img) = OciImage::open(repo, &digest, None) {
+            let counterparts = img.linked_erofs_images(id);
+            if !counterparts.is_empty() {
+                return Ok(counterparts);
             }
         }
-
-        Err(anyhow::anyhow!("No EROFS image found {}", id.to_hex()))
     }
+
+    Err(anyhow::anyhow!("No EROFS image found {}", id.to_hex()))
 }
 
 // =============================================================================
@@ -4282,10 +4273,10 @@ mod test {
         assert_eq!(all, expected_all);
 
         // Repo-level extension trait
-        let mut repo_result = repo.linked_erofs_images(&fake_boot_v2).unwrap();
+        let mut repo_result = linked_erofs_images(repo, &fake_boot_v2).unwrap();
         repo_result.sort_by_key(|c| c.id.to_hex());
         assert_eq!(repo_result, expected_all);
 
-        assert!(repo.linked_erofs_images(&unknown).is_err());
+        assert!(linked_erofs_images(repo, &unknown).is_err());
     }
 }

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -48,6 +48,8 @@ use rustix::fs::{AtFlags, Dir, Mode, OFlags, openat, readlinkat, unlinkat};
 use rustix::io::Errno;
 use serde::Serialize;
 
+use fn_error_context::context;
+
 use composefs::{
     erofs::format::{FormatEpoch, FormatVersion},
     fsverity::FsVerityHashValue,
@@ -381,6 +383,61 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         })
     }
 
+    /// Given an EROFS image ObjectID (boot or non-boot), returns all
+    /// counterparts from the opposite category at the same epoch
+    ///
+    /// - Non-boot ref: returns the boot ref at the same epoch
+    /// - Boot ref: returns the non-boot ref at the same epoch
+    /// - Unknown `id`: returns an empty vec.
+    pub fn erofs_counterparts(&self, id: &ObjectID) -> Vec<&ObjectID> {
+        for (key, value) in &self.boot_image_refs {
+            if value != id {
+                continue;
+            }
+
+            let non_boot = if key.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
+                self.image_ref_v1.as_ref()
+            } else {
+                self.image_ref.as_ref()
+            };
+
+            return non_boot.into_iter().collect();
+        }
+
+        // Non boot image passed in
+        if self.image_ref.as_ref() == Some(id) {
+            let mut v = vec![];
+
+            for (boot_img, id) in &self.boot_image_refs {
+                if boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
+                    continue;
+                }
+
+                if !boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY) {
+                    continue;
+                }
+
+                v.push(id);
+            }
+
+            return v;
+        }
+
+        if self.image_ref_v1.as_ref() == Some(id) {
+            let mut v = vec![];
+
+            for (boot_img, id) in &self.boot_image_refs {
+                if boot_img.starts_with(crate::BOOT_IMAGE_REF_KEY_V1) {
+                    v.push(id);
+                }
+            }
+
+            return v;
+        }
+
+        Vec::new()
+    }
+
     /// Reads the already-committed EROFS image for this OCI image back into a
     /// `FileSystem`, in-process — no kernel mount, and no re-walk of the OCI
     /// tar layers (this decodes the EROFS binary format directly via
@@ -590,6 +647,28 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
     }
 }
 
+/// Extension trait that adds OCI EROFS counterpart lookups to [`Repository`].
+pub trait RepositoryOciExt<ObjectID: FsVerityHashValue> {
+    /// Given an EROFS image ObjectID (boot or non-boot), scans all tagged OCI
+    /// images and returns every counterpart from the opposite category.
+    fn erofs_counterparts(&self, id: &ObjectID) -> Result<Vec<ObjectID>>;
+}
+
+impl<ObjectID: FsVerityHashValue> RepositoryOciExt<ObjectID> for Repository<ObjectID> {
+    fn erofs_counterparts(&self, id: &ObjectID) -> Result<Vec<ObjectID>> {
+        for (_, digest) in list_refs(self)? {
+            if let Ok(img) = OciImage::open(self, &digest, None) {
+                let counterparts = img.erofs_counterparts(id);
+                if !counterparts.is_empty() {
+                    return Ok(counterparts.into_iter().cloned().collect());
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("No EORFS image found {}", id.to_hex()))
+    }
+}
+
 // =============================================================================
 // Reference Management (GC Roots)
 // =============================================================================
@@ -682,6 +761,7 @@ pub fn resolve_ref<ObjectID: FsVerityHashValue>(
 /// Lists all tagged OCI images.
 ///
 /// Returns (name, manifest_digest) pairs for each tag.
+#[context("Lising oci image refs")]
 pub fn list_refs<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
 ) -> Result<Vec<(String, OciDigest)>> {

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -575,7 +575,9 @@ impl DeltaSuperblock {
                     obj_data.len()
                 );
                 let objects = obj_data
-                    .chunks_exact(OBJTYPE_CSUM_LEN)
+                    .as_chunks::<OBJTYPE_CSUM_LEN>()
+                    .0
+                    .iter()
                     .map(|chunk| {
                         let obj_type = ObjectType::from_byte(chunk[0])?;
                         let csum: Sha256Digest = chunk[1..33]

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -815,19 +815,27 @@ impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for RemoteRepo<ObjectID> 
         let file_header: AlignedBuf = header_buf.into();
 
         let header = OstreeFileHeader::from_zlib_sized(&file_header)?;
+        let is_symlink = FileType::from_raw_mode(header.mode as rustix::fs::RawMode).is_symlink();
 
         let checksum = *checksum;
         let repo = self.repo.clone();
 
-        // Convert the async stream to a sync reader for decompression
-        let sync_reader = tokio_util::io::SyncIoBridge::new(reader);
-        let mut decompressor = DeflateDecoder::new(sync_reader);
+        if is_symlink {
+            tokio::task::spawn_blocking(move || {
+                hash_and_store_file(&repo, &header, file_header, &mut empty(), &checksum)
+            })
+            .await
+            .context("spawn_blocking failed")?
+        } else {
+            let sync_reader = tokio_util::io::SyncIoBridge::new(reader);
+            let mut decompressor = DeflateDecoder::new(sync_reader);
 
-        tokio::task::spawn_blocking(move || {
-            hash_and_store_file(&repo, &header, file_header, &mut decompressor, &checksum)
-        })
-        .await
-        .context("spawn_blocking failed")?
+            tokio::task::spawn_blocking(move || {
+                hash_and_store_file(&repo, &header, file_header, &mut decompressor, &checksum)
+            })
+            .await
+            .context("spawn_blocking failed")?
+        }
     }
 
     async fn try_pull_delta(
@@ -1214,8 +1222,17 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
             file.read_exact(&mut v[header_size..])
         })?;
 
-        // Decompress rest
-        Ok((header_buf, Box::new(DeflateDecoder::new(file))))
+        // Symlink objects have no compressed content after the header.
+        // Wrapping an empty input in DeflateDecoder fails on some zlib
+        // implementations, so return an empty reader in that case.
+        let file_len = file.metadata()?.len();
+        let header_total = (header_size + variant_size) as u64;
+
+        if header_total >= file_len {
+            Ok((header_buf, Box::new(empty())))
+        } else {
+            Ok((header_buf, Box::new(DeflateDecoder::new(file))))
+        }
     }
 }
 


### PR DESCRIPTION
oci/repo: Add function to return EROFS counterparts

Add an extension trait to Repository which contains a single fuction
which receives an EROFS image's fsverity and returns the non-bootable
counterpart if the passed in image was a bootable one and vice-versa.

Traverses all oci image refs to find the image and its counterparts

---

cli: Add option to get erofs counterparts

---

Add tests for erofs-counterparts

---

This simplifies https://github.com/bootc-dev/bootc/pull/2380