### PR TITLE
Add missing CLOEXEC across the project

### DIFF
--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -716,7 +716,7 @@ pub fn linked_erofs_images<ObjectID: FsVerityHashValue>(
     let streams_dir_fd = rustix::fs::openat(
         repo.repo_fd(),
         "streams",
-        OFlags::RDONLY | OFlags::DIRECTORY,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
         rustix::fs::Mode::empty(),
     )?;
 

--- a/crates/composefs-ostree/src/lib.rs
+++ b/crates/composefs-ostree/src/lib.rs
@@ -165,7 +165,7 @@ fn resolve_commit_prefix<ObjectID: FsVerityHashValue>(
     let dir_fd = rustix::fs::openat(
         repo.repo_fd(),
         "streams",
-        OFlags::RDONLY | OFlags::DIRECTORY,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
         rustix::fs::Mode::empty(),
     )?;
     let mut match_name: Option<String> = None;
@@ -275,7 +275,7 @@ fn list_local_commit_ids<ObjectID: FsVerityHashValue>(
     let dir_fd = rustix::fs::openat(
         repo.repo_fd(),
         "streams",
-        OFlags::RDONLY | OFlags::DIRECTORY,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
         rustix::fs::Mode::empty(),
     )?;
     let mut ids = HashSet::new();

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -3033,7 +3033,10 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         mode: GCCategoryWalkMode,
     ) -> Result<Vec<(ObjectID, String)>> {
         let Some(category_fd) = self
-            .openat(category, OFlags::RDONLY | OFlags::DIRECTORY)
+            .openat(
+                category,
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
+            )
             .filter_errno(Errno::NOENT)
             .context(format!("Opening {category} dir in repository"))?
         else {
@@ -3148,7 +3151,10 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     #[context("Cleaning up broken links in {category} category")]
     fn cleanup_gc_category(&self, category: &'static str, dry_run: bool) -> Result<u64> {
         let Some(category_fd) = self
-            .openat(category, OFlags::RDONLY | OFlags::DIRECTORY)
+            .openat(
+                category,
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
+            )
             .filter_errno(Errno::NOENT)
             .context(format!("Opening {category} dir in repository"))?
         else {
@@ -3570,7 +3576,10 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         let is_streams = category == "streams";
 
         let Some(category_fd) = self
-            .openat(category, OFlags::RDONLY | OFlags::DIRECTORY)
+            .openat(
+                category,
+                OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY,
+            )
             .filter_errno(Errno::NOENT)
             .with_context(|| format!("Opening {category} directory"))?
         else {


### PR DESCRIPTION
Had initially added a `streams_dir` method to `Repository` but that turned out to be pretty inefficient as we usually open the streams dir to only read from. The `images_dir` and `objects_dir` are opened `O_PATH` and following the same for `streams_dir` would fail with `EBADFD` when reading directory entries

Closes: #389