### PR TITLE
Release 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/containers/composefs-rs"
 rust-version = "1.88.0"
-version = "0.9.1"
+version = "0.9.2"
 
 [workspace.lints.rust]
 missing_docs = "deny"
@@ -33,14 +33,14 @@ missing_debug_implementations = "deny"
 unsafe_code = "deny" # https://github.com/containers/composefs-rs/issues/123
 
 [workspace.dependencies]
-composefs = { version = "0.9.1", path = "crates/composefs", default-features = false }
-composefs-ctl = { version = "0.9.1", path = "crates/composefs-ctl", default-features = false }
-composefs-ioctls = { version = "0.9.1", path = "crates/composefs-ioctls", default-features = false }
-composefs-oci = { version = "0.9.1", path = "crates/composefs-oci", default-features = false }
-composefs-boot = { version = "0.9.1", path = "crates/composefs-boot", default-features = false }
-composefs-fuse = { version = "0.9.1", path = "crates/composefs-fuse", default-features = false }
-composefs-http = { version = "0.9.1", path = "crates/composefs-http", default-features = false }
-composefs-ostree = { version = "0.9.1", path = "crates/composefs-ostree", default-features = false }
+composefs = { version = "0.9.2", path = "crates/composefs", default-features = false }
+composefs-ctl = { version = "0.9.2", path = "crates/composefs-ctl", default-features = false }
+composefs-ioctls = { version = "0.9.2", path = "crates/composefs-ioctls", default-features = false }
+composefs-oci = { version = "0.9.2", path = "crates/composefs-oci", default-features = false }
+composefs-boot = { version = "0.9.2", path = "crates/composefs-boot", default-features = false }
+composefs-fuse = { version = "0.9.2", path = "crates/composefs-fuse", default-features = false }
+composefs-http = { version = "0.9.2", path = "crates/composefs-http", default-features = false }
+composefs-ostree = { version = "0.9.2", path = "crates/composefs-ostree", default-features = false }
 cap-std-ext = "5.1.2"
 ocidir = "0.8.0"
 

--- a/crates/composefs-ctl/Cargo.toml
+++ b/crates/composefs-ctl/Cargo.toml
@@ -36,9 +36,9 @@ comfy-table = { version = "8.0", default-features = false }
 composefs = { workspace = true, features = ["varlink"] }
 composefs-boot = { workspace = true }
 composefs-oci = { workspace = true, optional = true, features = ["boot"] }
-composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.1", optional = true }
+composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.2", optional = true }
 composefs-http = { workspace = true, optional = true }
-cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.9.1", features = ["layer-transfer"], optional = true }
+cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.9.2", features = ["layer-transfer"], optional = true }
 cap-std-ext = { workspace = true }
 composefs-fuse = { workspace = true, optional = true }
 composefs-ostree = { workspace = true, optional = true }

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
 async-compression = { version = "0.4.43", default-features = false, features = ["tokio", "zstd", "gzip"] }
 base64 = { version = "0.23", default-features = false, features = ["std"], optional = true }
-composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.1", features = ["tokio"] }
+composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.2", features = ["tokio"] }
 bytes = { version = "1", default-features = false }
 composefs = { workspace = true }
 zlink = { workspace = true, optional = true }
@@ -30,7 +30,7 @@ zlink-core = { workspace = true, optional = true }
 composefs-boot = { workspace = true, optional = true }
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 containers-image-proxy = { version = "0.11", default-features = false }
-cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.9.1", optional = true }
+cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.9.2", optional = true }
 hex = { version = "0.4.0", default-features = false }
 indicatif = { version = "0.18.0", default-features = false }
 rustix = { version = "1.0.0", features = ["fs"] }

--- a/crates/composefs-storage/Cargo.toml
+++ b/crates/composefs-storage/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1.0", default-features = false, features = ["std"] }
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 cap-std = { version = "4.0", default-features = false }
 cap-std-ext = { version = "5.0", default-features = false }
-composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.1", optional = true, features = ["tokio"] }
+composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.9.2", optional = true, features = ["tokio"] }
 crc = { version = "3.0", default-features = false }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 oci-spec = { version = "0.10", default-features = false, features = ["image"] }


### PR DESCRIPTION
We had https://github.com/composefs/composefs-rs/pull/388, but never ended up pushing the tag and I think re-creating the same release is a bit confusing, so bumping a minor version again.

Main difference from `v0.9.1` is https://github.com/composefs/composefs-rs/pull/390